### PR TITLE
Replace (indptr, indices, data) tuple with CSGraph jitclass

### DIFF
--- a/benchmarks/bench_skan.py
+++ b/benchmarks/bench_skan.py
@@ -40,7 +40,7 @@ def print_bench_results(times=None, memory=None):
     if times is not None:
         print('Timing results:')
         for key in times:
-            print('--- ', key, times[key])
+            print('--- ', key, '%.3f s' % times[key])
     if memory is not None:
         print('Memory results:')
         for key in memory:

--- a/benchmarks/bench_skan.py
+++ b/benchmarks/bench_skan.py
@@ -1,0 +1,52 @@
+import os
+
+from contextlib import contextmanager
+from collections import OrderedDict
+from time import process_time
+
+import numpy as np
+
+from skan import csr
+
+rundir = os.path.dirname(__file__)
+
+
+@contextmanager
+def timer():
+    time = []
+    t0 = process_time()
+    yield time
+    t1 = process_time()
+    time.append(t1 - t0)
+
+
+def bench_suite():
+    times = OrderedDict()
+    skeleton = np.load('infected3.npz')['skeleton']
+    with timer() as t_build_graph:
+        g, indices, degrees = csr.skeleton_to_csgraph(skeleton,
+                                                      spacing=2.24826)
+    times['build graph'] = t_build_graph[0]
+    with timer() as t_stats:
+        stats = csr.branch_statistics(g, indices, degrees)
+    times['compute statistics'] = t_stats[0]
+    with timer() as t_summary:
+        summary = csr.summarise(skeleton)
+    times['compute per-skeleton statistics'] = t_summary[0]
+    return times
+
+
+def print_bench_results(times=None, memory=None):
+    if times is not None:
+        print('Timing results:')
+        for key in times:
+            print('--- ', key, times[key])
+    if memory is not None:
+        print('Memory results:')
+        for key in memory:
+            print('--- ', key, '%.3f MB' % (memory[key] / 1e6))
+
+
+if __name__ == '__main__':
+    times, memory = bench_suite()
+    print_bench_results(times, memory)

--- a/benchmarks/bench_skan.py
+++ b/benchmarks/bench_skan.py
@@ -22,7 +22,7 @@ def timer():
 
 def bench_suite():
     times = OrderedDict()
-    skeleton = np.load('infected3.npz')['skeleton']
+    skeleton = np.load(os.path.join(rundir, 'infected3.npz'))['skeleton']
     with timer() as t_build_graph:
         g, indices, degrees = csr.skeleton_to_csgraph(skeleton,
                                                       spacing=2.24826)

--- a/benchmarks/bench_skan.py
+++ b/benchmarks/bench_skan.py
@@ -30,6 +30,9 @@ def bench_suite():
     with timer() as t_stats:
         stats = csr.branch_statistics(g, indices, degrees)
     times['compute statistics'] = t_stats[0]
+    with timer() as t_stats2:
+        stats = csr.branch_statistics(g, indices, degrees)
+    times['compute statistics again'] = t_stats2[0]
     with timer() as t_summary:
         summary = csr.summarise(skeleton)
     times['compute per-skeleton statistics'] = t_summary[0]

--- a/benchmarks/bench_skan.py
+++ b/benchmarks/bench_skan.py
@@ -48,5 +48,5 @@ def print_bench_results(times=None, memory=None):
 
 
 if __name__ == '__main__':
-    times, memory = bench_suite()
-    print_bench_results(times, memory)
+    times = bench_suite()
+    print_bench_results(times)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.11
 scipy>=1.18
 networkx>=1.11
 numba>=0.29
+pandas>=0.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [tool:pytest]
-addopts = --doctest-modules --cov-report term-missing --cov . --ignore setup.py
+addopts = --doctest-modules  --ignore setup.py --ignore benchmarks/
+; use "--cov-report term-missing --cov ." to also run coverage.
+; remember to clear numba cache and disable Numba JIT for accurate coverage.
+; use "make numba-clean" and "export NUMBA_DISABLE_JIT=1".

--- a/skan/csr.py
+++ b/skan/csr.py
@@ -145,7 +145,7 @@ def _csrget(indices, indptr, data, row, col):
     return 0.
 
 
-@numba.jit(nopython=True, cache=True)
+@numba.jit(nopython=True)
 def _expand_path(graph, source, step, visited, degrees):
     d = graph.edge(source, step)
     while degrees[step] == 2 and not visited[step]:

--- a/skan/csr.py
+++ b/skan/csr.py
@@ -9,6 +9,31 @@ from .nputil import pad, raveled_steps_to_neighbors
 
 ## CSGraph and Numba-based implementation
 
+csr_spec = [
+    ('indptr', numba.int32[:]),
+    ('indices', numba.int32[:]),
+    ('data', numba.float64[:]),
+    ('shape', numba.int32[:])
+]
+
+@numba.jitclass(csr_spec)
+class CSGraph:
+    def __init__(self, indptr, indices, data, shape):
+        self.indptr = indptr
+        self.indices = indices
+        self.data = data
+        self.shape = shape
+
+    @property
+    def ndim(self):
+        return self.shape.size
+
+    def edge(self, i, j):
+        return _csrget(self.indices, self.indptr, self.data, i, j)
+
+    def neighbors(self, row):
+        loc, stop = self.indptr[row], self.indptr[row+1]
+        return self.indices[loc:stop]
 
 
 @numba.jit(nopython=True, cache=True, nogil=True)
@@ -121,14 +146,13 @@ def _csrget(indices, indptr, data, row, col):
 
 
 @numba.jit(nopython=True, cache=True)
-def _expand_path(indices, indptr, data, source, step, visited, degrees):
-    d = _csrget(indices, indptr, data, source, step)
+def _expand_path(graph, source, step, visited, degrees):
+    d = graph.edge(source, step)
     while degrees[step] == 2 and not visited[step]:
-        loc = indptr[step]
-        n1, n2 = indices[loc], indices[loc+1]
+        n1, n2 = graph.neighbors(step)
         nextstep = n1 if n1 != source else n2
         source, step = step, nextstep
-        d += _csrget(indices, indptr, data, source, step)
+        d += graph.edge(source, step)
         visited[source] = True
     return step, d, degrees[step]
 
@@ -165,6 +189,8 @@ def branch_statistics(graph, pixel_indices, degree_image, *,
         - junction-junction (2)
         - path-path (3) (This can only be a standalone cycle)
     """
+    jgraph = CSGraph(graph.indptr, graph.indices, graph.data,
+                     np.array(graph.shape, np.int32))
     degree_image = degree_image.ravel()
     degrees = degree_image[pixel_indices]
     visited = np.zeros(pixel_indices.shape, dtype=bool)
@@ -175,17 +201,13 @@ def branch_statistics(graph, pixel_indices, degree_image, *,
     for node in range(1, graph.shape[0]):
         if degrees[node] == 2 and not visited[node]:
             visited[node] = True
-            loc = graph.indptr[node]
-            left, right = graph.indices[loc:loc+2]
-            id0, d0, deg0 = _expand_path(graph.indices, graph.indptr,
-                                         graph.data, node, left, visited,
-                                         degrees)
+            left, right = jgraph.neighbors(node)
+            id0, d0, deg0 = _expand_path(jgraph, node, left, visited, degrees)
             if id0 == node:  # standalone cycle
                 id1, d1, deg1 = node, 0., 2
                 kind = 3
             else:
-                id1, d1, deg1 = _expand_path(graph.indices, graph.indptr,
-                                             graph.data, node, right, visited,
+                id1, d1, deg1 = _expand_path(jgraph, node, right, visited,
                                              degrees)
                 kind = 2  # default: junction-to-junction
                 if deg0 == 1 and deg1 == 1:  # tip-tip

--- a/skan/test/test_csr.py
+++ b/skan/test/test_csr.py
@@ -26,8 +26,8 @@ def test_tiny_cycle():
 
 
 def test_skeleton1_stats():
-    args = csr.skeleton_to_csgraph(skeleton1)
-    stats = csr.branch_statistics(*args)
+    g, idxs, degimg = csr.skeleton_to_csgraph(skeleton1)
+    stats = csr.branch_statistics(g, idxs, degimg)
     assert_equal(stats.shape, (4, 4))
     keys = map(tuple, stats[:, :2].astype(int))
     dists = stats[:, 2]

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -9,3 +9,4 @@ dependencies:
 - pytest>=3*
 - coverage>=4.0
 - pytest-cov>=2.2
+- pandas>=0.18*

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -2,6 +2,7 @@ name: skantest
 dependencies:
 - python>=3.5*
 - setuptools>=19.6*
+- numba>=0.29
 - numpy>=1.11*
 - numpydoc>=0.5*
 - scipy>=0.17*


### PR DESCRIPTION
This is [cannot currently be combined](https://groups.google.com/a/continuum.io/forum/#!msg/numba-users/6-AFAJgRF6s/q1CqDSBoAAAJ) with cache=True for functions that read in the class, but the warmup time is acceptable:

Timings before this PR:
---  build graph 0.302 s
---  compute statistics 0.212 s
---  compute per-skeleton statistics 0.469 s

Timings with this PR:
---  build graph 0.298 s
---  compute statistics 1.037 s
---  compute statistics again 0.190 s
---  compute per-skeleton statistics 0.456 s